### PR TITLE
Prevent error from empty string identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var transforms = [
   },
   // e.g. 'ZLIB'
   function(argument) {
-    return argument[0].toUpperCase() + argument.slice(1);
+    return argument.charAt(0) + argument.slice(1);
   },
   // e.g. 'MPL/2.0'
   function(argument) {


### PR DESCRIPTION
When the identifier passed to **spdx-correct** is an empty string, the following error is raised:

`TypeError: Cannot read property 'toUpperCase' of undefined`

This is because when attempting to upcase the first letter of the string, `''[0]` returns `undefined`. Instead using `''.charAt(0)` returns `''`, preventing the type change.
