### PR TITLE
Handle npm SPDX exceptions

### DIFF
--- a/examples.test.js
+++ b/examples.test.js
@@ -1,5 +1,5 @@
 var test = require('tape')
-var valid = require('validate-npm-package-license');
+var valid = require('validate-npm-package-license')
 var correct = require('./')
 
 /* eslint-disable max-len */
@@ -355,17 +355,17 @@ test('examples', function (test) {
     .forEach(function (input) {
       var expected = examples[input]
       test.test(input, function (test) {
-        var actual = correct(input);
+        var actual = correct(input)
         test.equal(
           actual, expected,
           'corrects "' + input + '" to "' + expected + '"'
-        );
+        )
         // also test expected just as a double check that our test case is correct
-        [actual, expected].forEach(function (name) {
+        ;[actual, expected].forEach(function (name) {
           if (name !== null) {
-            test.ok(valid(name).validForNewPackages, '"' + name + '" is a valid SPDX identifier');
+            test.ok(valid(name).validForNewPackages, '"' + name + '" is a valid SPDX identifier')
           }
-        });
+        })
         test.end()
       })
     })

--- a/examples.test.js
+++ b/examples.test.js
@@ -1,15 +1,6 @@
 var test = require('tape')
-var parse = require('spdx-expression-parse')
+var valid = require('validate-npm-package-license');
 var correct = require('./')
-
-function valid (string) {
-  try {
-    parse(string)
-    return true
-  } catch (e) {
-    return false
-  }
-}
 
 /* eslint-disable max-len */
 var examples = {
@@ -331,16 +322,18 @@ var examples = {
   'Public Domain <Unlicense>': 'Unlicense',
   'Public domain(unlicense)': 'Unlicense',
   'Public-domain (Unlicense)': 'Unlicense',
+  'SEE LICENSE IN BEER': 'SEE LICENSE IN BEER',
+  'SEE LICENSE IN LICENSE': 'SEE LICENSE IN LICENSE',
   'Standard 3-clause BSD': 'BSD-3-Clause',
   'The Unlicense': 'Unlicense',
   'UNLICENSE': 'Unlicense',
-  'UNLICENSED': 'Unlicense',
+  'UNLICENSED': 'UNLICENSED',
   'UNLICNSE': 'Unlicense',
   'Unlicence': 'Unlicense',
   'Unlicense (http://unlicense.org/)': 'Unlicense',
   'Unlicense (see http://unlicense.org/)': 'Unlicense',
   'Unlicense': 'Unlicense',
-  'Unlicensed': 'Unlicense',
+  'Unlicensed': 'UNLICENSED',
   'WTF': 'WTFPL',
   'WTFGPL': 'WTFPL',
   'WTFPL 2': 'WTFPL',
@@ -360,19 +353,19 @@ var examples = {
 test('examples', function (test) {
   Object.keys(examples)
     .forEach(function (input) {
-      var corrected = examples[input]
+      var expected = examples[input]
       test.test(input, function (test) {
+        var actual = correct(input);
         test.equal(
-          correct(input),
-          corrected,
-          'corrects "' + input + '" to "' + corrected + '"'
-        )
-        if (corrected !== null) {
-          test.ok(
-            valid(corrected),
-            '"' + corrected + '" is a valid SPDX identifier'
-          )
-        }
+          actual, expected,
+          'corrects "' + input + '" to "' + expected + '"'
+        );
+        // also test expected just as a double check that our test case is correct
+        [actual, expected].forEach(function (name) {
+          if (name !== null) {
+            test.ok(valid(name).validForNewPackages, '"' + name + '" is a valid SPDX identifier');
+          }
+        });
         test.end()
       })
     })

--- a/index.js
+++ b/index.js
@@ -1,13 +1,4 @@
-var parse = require('spdx-expression-parse')
-
-function valid (string) {
-  try {
-    parse(string)
-    return true
-  } catch (error) {
-    return false
-  }
-}
+var valid = require('validate-npm-package-license');
 
 // Common transpositions of license identifier acronyms
 var transpositions = [
@@ -178,7 +169,7 @@ var IDENTIFIER = 1
 var validTransformation = function (identifier) {
   for (var i = 0; i < transforms.length; i++) {
     var transformed = transforms[i](identifier).trim()
-    if (transformed !== identifier && valid(transformed)) {
+    if (transformed !== identifier && valid(transformed).validForNewPackages) {
       return transformed
     }
   }
@@ -223,7 +214,7 @@ module.exports = function (identifier) {
     throw Error('Invalid argument. Expected non-empty string.')
   }
   identifier = identifier.replace(/\+$/, '').trim()
-  if (valid(identifier)) {
+  if (valid(identifier).validForNewPackages) {
     return identifier
   }
   var transformed = validTransformation(identifier)
@@ -231,7 +222,7 @@ module.exports = function (identifier) {
     return transformed
   }
   transformed = anyCorrection(identifier, function (argument) {
-    if (valid(argument)) {
+    if (valid(argument).validForNewPackages) {
       return argument
     }
     return validTransformation(argument)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var valid = require('validate-npm-package-license');
+var valid = require('validate-npm-package-license')
 
 // Common transpositions of license identifier acronyms
 var transpositions = [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
-    "spdx-expression-parse": "^1.0.4"
+    "validate-npm-package-license": "^3.0.1"
   },
   "devDependencies": {
     "defence-cli": "^1.0.1",


### PR DESCRIPTION
`npm` allows for some non-SPDX expressions:

- "SEE LICENSE IN \<filename\>"
- "UNLICENSED" (not to be confused with Unlicense!!)

See https://docs.npmjs.com/files/package.json#license

I changed the code to use the package `validate-npm-package-license`, however, it depends on this package and this might create a [circular dependency](https://github.com/kemitchell/validate-npm-package-license.js/blob/master/package.json#L7). Is this a problem?
