### PR TITLE
MIT/X11 -> X11

### DIFF
--- a/examples.test.js
+++ b/examples.test.js
@@ -299,7 +299,7 @@ var examples = {
   'MIT-Style': 'MIT',
   'MIT-like': 'MIT',
   'MIT/X': 'MIT',
-  'MIT/X11': 'MIT',
+  'MIT/X11': 'X11',
   'MIT2': 'MIT',
   'MITISC': 'MIT',
   'MIT]': 'MIT',

--- a/index.js
+++ b/index.js
@@ -200,6 +200,7 @@ var lastResorts = [
   ['GNU', 'GPL-3.0'],
   ['LGPL', 'LGPL-3.0'],
   ['GPL', 'GPL-3.0'],
+  ['X11', 'X11'],
   ['MIT', 'MIT'],
   ['MPL', 'MPL-2.0'],
   ['X11', 'X11'],


### PR DESCRIPTION
Over 165 npm packages state `MIT/X11` as their license and as far as I understand the correct SPDX ID for that would be `X11`, not `MIT`.